### PR TITLE
Disallow multiple AimIKBehaviour

### DIFF
--- a/Aim-IK/AimIKBehaviour.cs
+++ b/Aim-IK/AimIKBehaviour.cs
@@ -5,6 +5,7 @@ namespace AimIK
     using Properties;
     using Functions;
 
+    [DisallowMultipleComponent]
     public class AimIKBehaviour : MonoBehaviour
     {
         public Transform head;


### PR DESCRIPTION
Disallow to add multiple `AimIKBehaviour` components to a game object.